### PR TITLE
Request method reference breaks Sinatra apps

### DIFF
--- a/lib/rack-request-id/version.rb
+++ b/lib/rack-request-id/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class RequestId
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end

--- a/lib/rack/request_id.rb
+++ b/lib/rack/request_id.rb
@@ -7,7 +7,7 @@ module Rack
     end
 
     def call(env)
-      Thread.current[:request_id] = request.env['HTTP_X_REQUEST_ID'] || SecureRandom.hex(16)
+      Thread.current[:request_id] = env['HTTP_X_REQUEST_ID'] || SecureRandom.hex(16)
       status, headers, body = @app.call(env)
       headers['X-Request-Id'] ||= Thread.current[:request_id]
       [status, headers, body]


### PR DESCRIPTION
Fix for request reference, which appears to only work for Rails applications.
