### PR TITLE
Add feature users to be able to use other storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ end
 
 TODO: proc option to override id format
 
+Optionally you can change storage. Storage objects must have `#[]` and `#[]=` method.
+
+```ruby
+require 'request_store'
+
+class MyApp < Sinatra::Base
+  use Rack::RequestId, storage: RequestStore
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/spec/integration/sinatra_spec.rb
+++ b/spec/integration/sinatra_spec.rb
@@ -7,14 +7,31 @@ module SinatraSpec
     get('/') { status(200) }
   end
 
+  class TestAppWithMyStorage < Sinatra::Base
+    use Rack::RequestId, storage: MyStorage
+    get('/') { status(200) }
+  end
+
   describe Rack::RequestId do
     include Rack::Test::Methods
 
-    let(:app) { TestApp.new }
+    context 'default storage' do
+      let(:app) { TestApp.new }
 
-    it 'adds an X-Request-Id header to the response' do
-      get '/'
-      expect(last_response["X-Request-Id"]).to_not be_nil
+      it 'adds an X-Request-Id header to the response' do
+        get '/'
+        expect(last_response["X-Request-Id"]).to_not be_nil
+      end
     end
+
+    context 'with other storage' do
+      let(:app) { TestAppWithMyStorage.new }
+
+      it 'adds an X-Request-Id header to the response' do
+        get '/'
+        expect(last_response["X-Request-Id"]).to_not be_nil
+      end
+    end
+
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,21 @@ $:.push(File.expand_path(File.dirname(__FILE__)))
 $:.push(File.expand_path(File.dirname(__FILE__)) + '/../lib')
 
 require 'rack-request-id'
+
+class MyStorage
+  class << self
+    def [](k)
+      storage[k]
+    end
+
+    def []=(k, v)
+      storage[k] =v
+    end
+
+    private
+
+    def storage
+      Thread.current[:my_storage] ||= {}
+    end
+  end
+end


### PR DESCRIPTION
This feature enables users to be able to select other storage objects.  In my case, I want to store ids through request_store gem, then referrers(e.g. logger) would like to fetch request ids from RequestStore instead of native `Thread.current`. The benefit of this option is that the implementation i.e `Thread.current` can be hidden from referrers.

This keeps backward compatibility.
